### PR TITLE
syskit: use app-level hook definitions instead of the user-facing API

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -1,7 +1,7 @@
 module RockGazebo
     module Syskit
         module ConfigurationExtension
-            ::Robot.config do
+            Roby.app.on_setup do
                 if Conf.sdf.world_path?
                     world_path = Conf.sdf.world_path
                 end
@@ -13,7 +13,7 @@ module RockGazebo
                 Conf.gazebo.localhost = true
             end
 
-            ::Robot.clear_models do
+            Roby.app.on_clear_models do
                 Conf.sdf.world_file_path = nil
                 Conf.sdf.has_profile_loaded = false
             end
@@ -35,7 +35,7 @@ module RockGazebo
                 Conf.sdf.load_sdf(*path, world_name: world_name)
             end
 
-            # Sets up Syskit to use gazebo configured to use the given world 
+            # Sets up Syskit to use gazebo configured to use the given world
             #
             # @return [Syskit::Deployment] a deployment object that represents
             #   gazebo itself
@@ -45,7 +45,7 @@ module RockGazebo
 
                 if !has_process_server?('gazebo')
                     if localhost
-                        options = Hash[host_id: 'localhost'] 
+                        options = Hash[host_id: 'localhost']
                     else
                         options = Hash.new
                     end
@@ -105,4 +105,3 @@ module RockGazebo
         ::Syskit::RobyApp::Configuration.include ConfigurationExtension
     end
 end
-


### PR DESCRIPTION
This is a prerequisite for the config-reloading pull request in Syskit, where the user-facing API on `Robot` gets reloaded by default but not the app API. We must use the Application API then.