### PR TITLE
add plugins as devices 

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -46,7 +46,6 @@ module RockGazebo
             def plugins_to_device(plugin, device_name, frame_name)
                 if plugin.filename =~ /gazebo_thruster/
                     require 'common_models/models/devices/gazebo/thruster'
-                    p device_name
                     device(CommonModels::Devices::Gazebo::Thruster, as: device_name, 
                         using: OroGen::RockGazebo::ThrusterTask)
                 end


### PR DESCRIPTION
The thruster plugin is part of simulation/orogen/rock_gazebo, and is already handled on the deployment side by the Syskit integration. Finish the integration by auto-adding devices based on the SDF.