### PR TITLE
avoid loading the whole bundle-based Orocos environment if not needed

### DIFF
--- a/bindings/ruby/bin/rock-gazebo
+++ b/bindings/ruby/bin/rock-gazebo
@@ -62,7 +62,11 @@ end
 require 'rock/bundles'
 # Workaround: default_loader calls Orocos.load unconditionally :(
 Orocos.disable_sigchld_handler = true
-Bundles.load
+if start
+    Bundles.load
+else
+    Bundles.setup_search_paths
+end
 SDF::XML.model_path = Rock::Gazebo.model_path
 
 _, args = Rock::Gazebo.resolve_worldfiles_and_models_arguments(args)

--- a/bindings/ruby/lib/rock/gazebo.rb
+++ b/bindings/ruby/lib/rock/gazebo.rb
@@ -78,7 +78,7 @@ module Rock
         end
 
         def self.initialize
-            Bundles.load
+            Bundles.setup_search_paths
             self.model_path = self.default_model_path
         end
 


### PR DESCRIPTION
This patch makes sure that we don't initialize Orocos in rock-gazebo
if we don't need it. This saves the loading of configuration files,
which can be significant, and generally avoids cluttering the CORBA
namespace for nothing.