### PR TITLE
fix naming of the spawned plugin tasks

### DIFF
--- a/src/RockBridge.cpp
+++ b/src/RockBridge.cpp
@@ -273,14 +273,17 @@ void RockBridge::instantiatePluginComponents(sdf::ElementPtr modelElement, Model
 {
     sdf::ElementPtr pluginElement = modelElement->GetElement("plugin");
     while(pluginElement) {
-        string pluginFilename = pluginElement->Get<string>("filename");
-        gzmsg << "RockBridge: found plugin "<< pluginFilename << endl;
+        string filename = pluginElement->Get<string>("filename");
+        string name = pluginElement->Get<string>("name");
+        gzmsg << "RockBridge: found plugin name='" << name << "' "
+              << "filename='" << filename << "'" << endl;
+
         // Add more model plugins testing them here
         if(pluginFilename == "libgazebo_thruster.so")
         {
-            ThrusterTask* thruster_task = new ThrusterTask();
-            thruster_task->setGazeboModel( model );
-            setupTaskActivity(thruster_task);
+            auto* task = new ThrusterTask();
+            task->setGazeboModel(name, model);
+            setupTaskActivity(task);
         }
 
         pluginElement = pluginElement->GetNextElement("plugin");


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/simulation-orogen-rock_gazebo/pull/19

The tasks would not actually use the name from the <plugin ...>
block. The Syskit integration, however, was using the plugin name
instead, which leads to very confusing situations (basically, one
had to always use the same name).