### PR TITLE
switch to lower rates for update rate tests

### DIFF
--- a/bindings/ruby/test/helpers.rb
+++ b/bindings/ruby/test/helpers.rb
@@ -216,13 +216,13 @@ module Helpers
                 # Gazebo can't reliably hold the 50 Hz. The IMU gets ~35 to ~38
                 # Checked that it's indeed due to samples not arriving in the
                 # task's callback
-                assert_includes 30...60, count
+                assert_includes 9...11, count
             end
 
             it 'honors the rate set in the SDF file' do
                 @task = gzserver "#{world_basename}-custom-rate.world", task_name
                 count = configure_start_count_samples_and_stop(port_name, 1)
-                assert_includes 9..11, count
+                assert_includes 4..6, count
             end
         end
     end

--- a/bindings/ruby/test/worlds/gps-custom-rate.world
+++ b/bindings/ruby/test/worlds/gps-custom-rate.world
@@ -11,7 +11,7 @@
         <static>true</static>
         <link name="l">
             <sensor name="g" type="gps">
-            <update_rate>10</update_rate>
+            <update_rate>5</update_rate>
             </sensor>
         </link>
     </model>

--- a/bindings/ruby/test/worlds/gps.world
+++ b/bindings/ruby/test/worlds/gps.world
@@ -1,8 +1,8 @@
 <sdf version="1.6">
 <world name="w">
     <physics type="ode" default="1">
-    <max_step_size>0.02</max_step_size>
-    <real_time_update_rate>50</real_time_update_rate>
+    <max_step_size>0.1</max_step_size>
+    <real_time_update_rate>10</real_time_update_rate>
     </physics>
 
     <spherical_coordinates>

--- a/bindings/ruby/test/worlds/imu-custom-rate.world
+++ b/bindings/ruby/test/worlds/imu-custom-rate.world
@@ -3,7 +3,7 @@
     <model name="m">
         <link name="l">
             <sensor name="i" type="imu">
-            <update_rate>10</update_rate>
+            <update_rate>5</update_rate>
             </sensor>
         </link>
     </model>

--- a/bindings/ruby/test/worlds/imu.world
+++ b/bindings/ruby/test/worlds/imu.world
@@ -1,8 +1,8 @@
 <sdf version="1.6">
 <world name="w">
     <physics type="ode" default="1">
-    <max_step_size>0.02</max_step_size>
-    <real_time_update_rate>50</real_time_update_rate>
+    <max_step_size>0.1</max_step_size>
+    <real_time_update_rate>10</real_time_update_rate>
     </physics>
 
     <model name="m">


### PR DESCRIPTION
Getting the IMU reliably at 50Hz does not seem possible. I've checked,
and it is indeed that we don't receive the messages at the rate we're
setting. The previous commit already set the bar rather low, but it
still randomly fails in CI. So, set it even lower.