### PR TITLE
completely remove the default rate test

### DIFF
--- a/bindings/ruby/test/helpers.rb
+++ b/bindings/ruby/test/helpers.rb
@@ -184,8 +184,7 @@ module Helpers
     end
 
     def self.common_sensor_behavior(
-        ctx, world_basename:, task_name:, port_name:, model_name:,
-             skip_one_update_per_cycle_test: false
+        ctx, world_basename:, task_name:, port_name:, model_name:
     )
         ctx.send(:describe, "common sensor behavior for #{model_name}") do
             it "exports the sensor using #{model_name}" do
@@ -209,14 +208,6 @@ module Helpers
                 reader = @task.port(port_name).reader
                 sleep 0.5
                 refute reader.read_new
-            end
-
-            unless skip_one_update_per_cycle_test
-                it 'outputs one sample per cycle by default' do
-                    @task = gzserver "#{world_basename}.world", task_name
-                    count = configure_start_count_samples_and_stop(port_name, 1)
-                    assert_includes 9..11, count
-                end
             end
 
             it 'honors the rate set in the SDF file' do

--- a/bindings/ruby/test/helpers.rb
+++ b/bindings/ruby/test/helpers.rb
@@ -184,7 +184,8 @@ module Helpers
     end
 
     def self.common_sensor_behavior(
-        ctx, world_basename:, task_name:, port_name:, model_name:
+        ctx, world_basename:, task_name:, port_name:, model_name:,
+             skip_one_update_per_cycle_test: false
     )
         ctx.send(:describe, "common sensor behavior for #{model_name}") do
             it "exports the sensor using #{model_name}" do
@@ -210,13 +211,12 @@ module Helpers
                 refute reader.read_new
             end
 
-            it 'outputs one sample per cycle by default' do
-                @task = gzserver "#{world_basename}.world", task_name
-                count = configure_start_count_samples_and_stop(port_name, 1)
-                # Gazebo can't reliably hold the 50 Hz. The IMU gets ~35 to ~38
-                # Checked that it's indeed due to samples not arriving in the
-                # task's callback
-                assert_includes 8..11, count
+            unless skip_one_update_per_cycle_test
+                it 'outputs one sample per cycle by default' do
+                    @task = gzserver "#{world_basename}.world", task_name
+                    count = configure_start_count_samples_and_stop(port_name, 1)
+                    assert_includes 9..11, count
+                end
             end
 
             it 'honors the rate set in the SDF file' do

--- a/bindings/ruby/test/test_plugin_ImuTask.rb
+++ b/bindings/ruby/test/test_plugin_ImuTask.rb
@@ -10,7 +10,8 @@ describe 'rock_gazebo::ImuTask' do
         self, world_basename: 'imu',
               task_name: '/gazebo:w:m:i',
               port_name: 'orientation_samples',
-              model_name: 'rock_gazebo::ImuTask'
+              model_name: 'rock_gazebo::ImuTask',
+              skip_one_update_per_cycle_test: true
     )
 
     def imu_configure_start_and_read_one_new_sample(world, port_name = 'orientation_samples')

--- a/bindings/ruby/test/test_plugin_ImuTask.rb
+++ b/bindings/ruby/test/test_plugin_ImuTask.rb
@@ -10,8 +10,7 @@ describe 'rock_gazebo::ImuTask' do
         self, world_basename: 'imu',
               task_name: '/gazebo:w:m:i',
               port_name: 'orientation_samples',
-              model_name: 'rock_gazebo::ImuTask',
-              skip_one_update_per_cycle_test: true
+              model_name: 'rock_gazebo::ImuTask'
     )
 
     def imu_configure_start_and_read_one_new_sample(world, port_name = 'orientation_samples')


### PR DESCRIPTION
The "explicit rate" test has not failed (yet), and let's hope it will
stay that way. The lesson here is that if you want some rate, make
sure that (1) Gazebo runs faster than the rate you want and (2)
you explicitly set it.

Event at 10Hz, the explicit rate test was working at least more often
than the default. It seems that something's wrong on the overall logic.

