### PR TITLE
add dependency on base/scripts

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -8,6 +8,7 @@
   <license>LGPLv2 or later</license>
   <depend package="base/cmake" />
 
+  <depend_optional package="base/scripts" />
   <depend_optional package="simulation/gazebo" />
   <depend_optional package="ruby-minitar" />
   <depend_optional package="tools/logger" />


### PR DESCRIPTION
This is needed by rock/gazebo to resolve the worlds and models.