### PR TITLE
Dynamic loading of tasks related to model plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.9)
+project(rock_gazebo
+        VERSION 0.2
+        DESCRIPTION "C++ gazebo plugin that interfaces Gazebo with a Rock system")
 find_package(Rock)
-rock_init(rock_gazebo 0.1)
+rock_init()
 
 option(BUILD_GAZEBO_PLUGIN "build the C++ gazebo plugin" ON)
 if (BUILD_GAZEBO_PLUGIN)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 In a bundle, scenes go in scenes/$scenename/$scenename.world. Bundle-specific
 models go in models/sdf/$modelname/{model.config,model.sdf}.
+
 ## Using Gazebo
 
 At the profile level, one can use SDF to declare the type of robot that is
@@ -77,8 +78,8 @@ on the definition.
 For instance
 
 ```ruby
-define('simulated_underwater_camera', Compositions::CameraSimulation).
-    transformer_uses_sdf_links_of(flat_fish_dev)
+define('simulated_underwater_camera', Compositions::CameraSimulation)
+   .transformer_uses_sdf_links_of(flat_fish_dev)
 ```
 
 where the argument is the device that represents a model in the SDF world.
@@ -91,7 +92,10 @@ robot do
   # Export the transformation from the `flat_fish::dvl` link of the `flat_fish`
   # model to the `flat_fish::imu` link of the `flat_fish` model. The create
   # device is called `dvl_velocity`
-  sdf_export_link(flat_fish_dev, as: 'dvl_velocity', from_frame: 'flat_fish::dvl', to_frame: 'flat_fish::dvl')
+  sdf_export_link(
+    flat_fish_dev, as: 'dvl_velocity',
+                   from_frame: 'flat_fish::dvl', to_frame: 'flat_fish::dvl'
+  )
 end
 ```
 
@@ -104,10 +108,72 @@ robot do
   # Export the transformation from the `flat_fish::dvl` link of the `flat_fish`
   # model to the `flat_fish::imu` link of the `flat_fish` model. The create
   # device is called `dvl_velocity`
-  sdf_export_link(flat_fish_dev, as: 'dvl_velocity', from_frame: 'flat_fish::dvl', to_frame: 'flat_fish::dvl').
-    period(0.1)
+  sdf_export_link(flat_fish_dev,
+                  as: 'dvl_velocity',
+                  from_frame: 'flat_fish::dvl', to_frame: 'flat_fish::dvl')
+    .period(0.1)
 end
 ```
+
+## Model, Sensors and Plugins
+
+Common Gazebo physical elements such as models and links, as well as sensors
+such as range finders (rays), cameras, imus are handled out-of-the box by
+this Gazebo/Syskit integration. When a model is added to a profile with
+`use_gazebo_model`, the integration creates devices of the right type that allow
+to access the data. The corresponding oroGen components are made available in
+the `simulation/orogen/rock_gazebo` package.
+
+At the inception of this Gazebo/Rock integration, two plugins were being
+developed for the simulation of underwater systems, `gazebo_underwater` and
+`gazebo_thruster`. To simplify an already long task, it had been decided to
+define the corresponding tasks in `simulation/orogen/rock_gazebo` and hardcode
+their support in the Syskit support. This obviously does not scale **at all**,
+and is now the deprecated method to handle plugins.
+
+Model plugins blocks may now have a `<task ... />` tag that defines the model
+of an oroGen task capable to expose the plugin functionality. For instance,
+the `libgazebo_underwater.so` plugin would be written:
+
+~~~ xml
+<plugin name="hydrodynamics" filename="libgazebo_underwater.so">
+    <task model="rock_gazebo::UnderwaterTask" />
+</plugin>
+~~~
+
+The `task` element does not list the task name, only its model, as the task
+name is derived from the plugin name (in this case it would be
+`$PREFIX:hydrodynamics` where $PREFIX is `$world:$model`.
+
+To define such a task, it must be a subclass of `rock_gazebo::ModelPluginTask`
+which is defined in `simulation/orogen/rock_gazebo`. To use in your own oroGen
+project, add the following to the oroGen definition:
+
+~~~ ruby
+using_task_library "rock_gazebo"
+
+task_context "Task", subclasses: "rock_gazebo::ModelPluginTask" do
+end
+~~~
+
+Your task will have to overload the virtual method
+
+~~~
+virtual void setGazeboModel(
+    std::string const& pluginName,
+    gazebo::physics::ModelPtr model
+);
+~~~
+
+At runtime, before any of the task's hooks have been called, this method is
+called to allow the task to link itself to the plugin. There is no way to
+directly access a plugin object, so the preferred method of communication is
+to use gazebo topics. The SDF plugin definition is however available through
+the model pointer.
+
+Note that, within Syskit, these tasks are made available for deployment. It
+is up to the plugin developer and/or the application integrator to define the
+relevant device models and declare the corresponding devices.
 
 ## Using SDF without Gazebo
 
@@ -115,7 +181,7 @@ A number of SDF-related functionality (static environment description,
 spherical coordinates, transformer setup) are desirable in a Syskit system even
 if not using Gazebo.
 
-This is done at the config level with 
+This is done at the config level with
 
 ```ruby
 Robot.init do
@@ -126,7 +192,7 @@ Robot.requires do
 end
 ```
 
-and at the profile level 
+and at the profile level
 
 ```ruby
 profile 'Base' do

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -150,7 +150,12 @@ module RockGazebo
     def self.setup_orogen_model_from_sdf_model_plugin(
         deployment, plugin, prefix: "", period: 0.1
     )
-        task_model = PLUGIN_TASK_MODELS.find { |k, _| k === plugin.filename }&.last
+        task_model =
+            if (task_xml = plugin.xml.elements["task"])
+                task_xml.attributes["model"]
+            else
+                PLUGIN_TASK_MODELS.find { |k, _| k === plugin.filename }&.last
+            end
 
         return unless task_model
 

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RockGazebo
     # Creation of an oroGen deployment model representing what the
     # rock-gazebo plugin would do from a SDF world
@@ -7,59 +9,151 @@ module RockGazebo
     # @param [OroGen::Loaders::Base] loader the oroGen loader that we should use
     #   to create the tasks
     # @return [OroGen::Spec::Deployment]
-    def self.orogen_model_from_sdf_world(name, world, loader: Orocos.default_loader, period: 0.1)
+    def self.orogen_model_from_sdf_world(
+        name, world, loader: Orocos.default_loader, period: 0.1
+    )
         project = OroGen::Spec::Project.new(loader)
-        project.using_task_library 'logger'
-        project.using_task_library 'rock_gazebo'
+        project.using_task_library "logger"
+        project.using_task_library "rock_gazebo"
         deployment = project.deployment(name)
-        setup_orogen_model_from_sdf_world(deployment, world, period: 0.1)
+        setup_orogen_model_from_sdf_world(deployment, world, period: period)
     end
 
-    def self.setup_orogen_model_from_sdf_world(deployment, world, period: 0.1)
-        deployment.task("gazebo:#{world.name}", "rock_gazebo::WorldTask").
-            periodic(period)
-        deployment.task("gazebo:#{world.name}_Logger", "logger::Logger").
-            periodic(period)
-        world.each_model do |model|
-            deployment.task("gazebo:#{world.name}:#{model.name}", "rock_gazebo::ModelTask").
-                periodic(period)
+    SENSORS_TASK_MODELS = {
+        "ray" => "rock_gazebo::LaserScanTask",
+        "camera" => "rock_gazebo::CameraTask",
+        "imu" => "rock_gazebo::ImuTask",
+        "gps" => "rock_gazebo::GPSTask"
+    }.freeze
 
-            model.each_sensor do |sensor|
-                if sensor.type == 'ray'
-                    deployment.task("gazebo:#{world.name}:#{model.name}:#{sensor.name}", "rock_gazebo::LaserScanTask").
-                        periodic(period)
-                elsif sensor.type == 'camera'
-                    deployment.task("gazebo:#{world.name}:#{model.name}:#{sensor.name}", "rock_gazebo::CameraTask").
-                        periodic(period)
-                elsif sensor.type == 'imu'
-                    deployment.task("gazebo:#{world.name}:#{model.name}:#{sensor.name}", "rock_gazebo::ImuTask").
-                        periodic(period)
-                elsif sensor.type == 'gps'
-                    deployment.task("gazebo:#{world.name}:#{model.name}:#{sensor.name}", "rock_gazebo::GPSTask").
-                        periodic(period)
-                end
-            end
-            model.each_plugin do |plugin|
-                case plugin.filename
-                when /gazebo_thruster/
-                    deployment.task("gazebo:#{world.name}:#{model.name}:#{plugin.name}", "rock_gazebo::ThrusterTask").
-                        periodic(period)
-                when /gazebo_underwater/
-                    deployment.task("gazebo:#{world.name}:#{model.name}:#{plugin.name}", "rock_gazebo::UnderwaterTask").
-                        periodic(period)
-                end
-            end
+    PLUGIN_TASK_MODELS = {
+        /gazebo_thruster/ => "rock_gazebo::ThrusterTask",
+        /gazebo_underwater/ => "rock_gazebo::UnderwaterTask"
+    }.freeze
+
+    # Add tasks to a deployment, matching the tasks that would be deployed by
+    # the rock-gazebo plugin
+    #
+    # This method configures an orogen deployment model to match what the
+    # rock-gazebo plugin would do when given the provided SDF world
+    #
+    # @param [OroGen::Spec::Deployment] deployment the model to modify
+    # @param [SDF::World] world the SDF world
+    # @param [Float] period the update period, which should match the SDF's physics
+    #   update rate.
+    #
+    # @see {.orogen_model_from_sdf_world}
+    def self.setup_orogen_model_from_sdf_world(deployment, world, period: 0.1)
+        deployment.task("gazebo:#{world.name}", "rock_gazebo::WorldTask")
+                  .periodic(period)
+        deployment.task("gazebo:#{world.name}_Logger", "logger::Logger")
+                  .periodic(period)
+
+        world.each_model do |model|
+            setup_orogen_model_from_sdf_model(
+                deployment, model, prefix: "gazebo:#{world.name}:", period: period
+            )
         end
+
         world.each_plugin do |plugin|
-            if plugin.name == 'rock_components'
-                plugin.xml.elements.each('task') do |task_element|
-                    deployment.task(task_element.attributes['name'], task_element.attributes['model']).
-                        periodic(period)
-                end
+            if plugin.name == "rock_components"
+                setup_orogen_model_from_rock_components_plugin(plugin)
             end
         end
 
         deployment
     end
-end
 
+    # @api private
+    #
+    # Add the tasks deployed through the rock_components "plugin" to an orogen model
+    #
+    # @param [OroGen::Spec::Deployment] deployment the deployment model to modify
+    # @param [SDF::Plugin] the plugin
+    # @param [Float] period the task's period in seconds
+    def self.setup_orogen_model_from_components_plugin(deployment, plugin, period: 0.1)
+        plugin.xml.elements.each("task") do |el|
+            deployment.task(el.attributes["name"], el.attributes["model"])
+                      .periodic(period)
+        end
+    end
+
+    # @api private
+    #
+    # Describe a model's rock task to a deployment, describing the rock-gazebo
+    # plugin's behavior
+    #
+    # The model's own task name is always gazebo:${world}:${model}. The method
+    # also adds tasks for the models sensors and plugins. See
+    # {#setup_orogen_model_from_sdf_model_sensor} and {#setup_orogen_model_from_sdf_model_plugin}
+    #
+    # @param [OroGen::Spec::Deployment] deployment the deployment model to modify
+    # @param [SDF::Model] the sensor description
+    # @param [String] prefix the string to be put before the plugin name in
+    #   the generated task name
+    # @param [Float] period the task's period in seconds
+    def self.setup_orogen_model_from_sdf_model(deployment, model, prefix: "", period: 0.1)
+        deployment.task("#{prefix}#{model.name}", "rock_gazebo::ModelTask")
+                  .periodic(period)
+
+        model.each_sensor do |sensor|
+            setup_orogen_model_from_sdf_model_sensor(
+                deployment, sensor, prefix: "#{prefix}#{model.name}:", period: period
+            )
+        end
+
+        model.each_plugin do |plugin|
+            setup_orogen_model_from_sdf_model_plugin(
+                deployment, plugin, prefix: "#{prefix}#{model.name}:", period: period
+            )
+        end
+    end
+
+    # @api private
+    #
+    # Describe a sensor's rock task to a deployment, describing the rock-gazebo
+    # plugin's behavior
+    #
+    # The task name is always gazebo:${world}:${model}:${sensor}. The task model
+    # is based on the sensor type, as listed in {SENSORS_TASK_MODELS}
+    #
+    # @param [OroGen::Spec::Deployment] deployment the deployment model to modify
+    # @param [SDF::Sensor] the sensor description
+    # @param [String] prefix the string to be put before the plugin name in
+    #   the generated task name
+    # @param [Float] period the task's period in seconds
+    def self.setup_orogen_model_from_sdf_model_sensor(
+        deployment, sensor, prefix: "", period: 0.1
+    )
+        return unless (task_model = SENSORS_TASK_MODELS[sensor.type])
+
+        deployment.task("#{prefix}#{sensor.name}", task_model)
+                  .periodic(period)
+    end
+
+    # @api private
+    #
+    # Describe a plugin's rock task to a deployment, describing the rock-gazebo
+    # plugin's behavior
+    #
+    # Tasks in plugins are explicitely specified with a <task .../> element.
+    # Only the plugins listed in PLUGIN_TASK_MODELS have hardcoded mapping from
+    # the plugin filename to the task model, for backward compatibility reasons
+    #
+    # The task name is always gazebo:${world}:${model}:${plugin}
+    #
+    # @param [OroGen::Spec::Deployment] deployment the deployment model to modify
+    # @param [SDF::Plugin] the plugin description
+    # @param [String] prefix the string to be put before the plugin name in
+    #   the generated task name
+    # @param [Float] period the task's period in seconds
+    def self.setup_orogen_model_from_sdf_model_plugin(
+        deployment, plugin, prefix: "", period: 0.1
+    )
+        task_model = PLUGIN_TASK_MODELS.find { |k, _| k === plugin.filename }&.last
+
+        return unless task_model
+
+        deployment.task("#{prefix}#{plugin.name}", task_model).periodic(period)
+    end
+end

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -50,14 +50,33 @@ module RockGazebo
             #   device model and device driver that should be used for this
             #   sensor
             def plugins_to_device(plugin, device_name, _frame_name)
+                has_task = false
+                plugin.xml.elements.to_a("task").each do |task_element|
+                    has_task = true
+                    case task_element.attributes["model"]
+                    when "rock_gazebo::ThrusterTask"
+                        require 'common_models/models/devices/gazebo/thruster'
+                        device(CommonModels::Devices::Gazebo::Thruster,
+                               as: device_name,
+                               using: OroGen.rock_gazebo.ThrusterTask)
+                    when "rock_gazebo::UdnerwaterTask"
+                        require 'common_models/models/devices/gazebo/underwater'
+                        device(CommonModels::Devices::Gazebo::Underwater,
+                               as: device_name,
+                               using: OroGen.rock_gazebo.UnderwaterTask)
+                    end
+                end
+
+                return if has_task
+
                 case plugin.filename
                 when /gazebo_thruster/
-                    require 'common_models/models/devices/gazebo/thruster'
+                    require "common_models/models/devices/gazebo/thruster"
                     device(CommonModels::Devices::Gazebo::Thruster,
                            as: device_name,
                            using: OroGen.rock_gazebo.ThrusterTask)
                 when /gazebo_underwater/
-                    require 'common_models/models/devices/gazebo/underwater'
+                    require "common_models/models/devices/gazebo/underwater"
                     device(CommonModels::Devices::Gazebo::Underwater,
                            as: device_name,
                            using: OroGen.rock_gazebo.UnderwaterTask)

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -55,15 +55,19 @@ module RockGazebo
                     has_task = true
                     case task_element.attributes["model"]
                     when "rock_gazebo::ThrusterTask"
-                        require 'common_models/models/devices/gazebo/thruster'
-                        device(CommonModels::Devices::Gazebo::Thruster,
-                               as: device_name,
-                               using: OroGen.rock_gazebo.ThrusterTask)
+                        require "common_models/models/devices/gazebo/thruster"
+                        return device(
+                            CommonModels::Devices::Gazebo::Thruster,
+                            as: device_name,
+                            using: OroGen.rock_gazebo.ThrusterTask
+                        )
                     when "rock_gazebo::UdnerwaterTask"
-                        require 'common_models/models/devices/gazebo/underwater'
-                        device(CommonModels::Devices::Gazebo::Underwater,
-                               as: device_name,
-                               using: OroGen.rock_gazebo.UnderwaterTask)
+                        require "common_models/models/devices/gazebo/underwater"
+                        return device(
+                            CommonModels::Devices::Gazebo::Underwater,
+                            as: device_name,
+                            using: OroGen.rock_gazebo.UnderwaterTask
+                        )
                     end
                 end
 

--- a/bindings/ruby/test/test_gazebo.rb
+++ b/bindings/ruby/test/test_gazebo.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rock_gazebo/test"
+require "rock/gazebo"
+
+module Rock
+    describe Gazebo do
+        describe ".process_sdf_world" do
+            it "resolve the 'filename' argument of a <task ...> element "\
+               "in <plugin ...>" do
+                loader = flexmock
+                task_model = create_task_model_mock(loader, "some::Task")
+                sdf = ::SDF::Root.from_string(
+                    <<~SDF
+                    <sdf><world><plugin>
+                        <task model="some::Task" />
+                    </plugin></world></sdf>
+                    SDF
+                )
+
+                xml = Gazebo.process_sdf_world(sdf, loader: loader)
+                task = REXML::XPath.first(xml, "//task")
+                assert_equal "some::Task_project_path", task.attributes["filename"]
+            end
+
+            it "auto-loads a task's dependent typekits" do
+                loader = flexmock
+                tk_a = create_typekit_mock(loader, "tk_a")
+                tk_b = create_typekit_mock(loader, "tk_b")
+                task_model = create_task_model_mock(
+                    loader, "some::Task",
+                    interface_typekits: { "tk_a" => tk_a, "tk_b" => tk_b }
+                )
+
+                sdf = ::SDF::Root.from_string(
+                    <<~SDF
+                    <sdf><world><plugin>
+                        <task model="some::Task" />
+                    </plugin></world></sdf>
+                    SDF
+                )
+
+                xml = Gazebo.process_sdf_world(sdf, loader: loader)
+                expected = %w[
+                    tk_a_library_path tk_a_transport_corba_path
+                    tk_a_transport_mqueue_path tk_a_transport_typelib_path
+                    tk_b_library_path tk_b_transport_corba_path
+                    tk_b_transport_mqueue_path tk_b_transport_typelib_path
+                ]
+                assert_world_loads_libraries(xml, expected)
+            end
+
+            def assert_world_loads_libraries(xml, expected)
+                loads =
+                    REXML::XPath
+                    .each(xml, "/sdf/world/plugin[@name='rock_components']/load")
+                    .map { |xml| xml.attributes["path"] }
+                assert_equal expected.to_set, loads.to_set
+            end
+
+            def create_task_model_mock(
+                loader, name,
+                interface_typekits: {}, project_name: "#{name}_project"
+            )
+                mock = flexmock
+                mock.should_receive(project: Struct.new(:name).new(project_name))
+                loader.should_receive(:task_model_from_name)
+                      .with(name).and_return(mock)
+                loader.should_receive(:task_library_path_from_name)
+                      .with(project_name).and_return("#{project_name}_path")
+
+                interface_types =
+                    interface_typekits.each_key.map { |tk_name| "#{tk_name}_type" }
+                mock.should_receive(:each_interface_type).and_iterates(*interface_types)
+                interface_typekits.each do |typekit_name, typekit|
+                    loader.should_receive(:typekit_for).with("#{typekit_name}_type")
+                          .and_return(typekit)
+                end
+            end
+
+            def create_typekit_mock(loader, name, virtual: false)
+                mock = flexmock
+                mock.should_receive(name: name, virtual?: virtual)
+                loader.should_receive(:typekit_library_path_from_name)
+                      .with(name).and_return("#{name}_library_path")
+                %w[typelib mqueue corba].each do |transport|
+                    loader.should_receive(:transport_library_path_from_name)
+                          .with(name, transport)
+                          .and_return("#{name}_transport_#{transport}_path")
+                end
+                mock
+            end
+        end
+    end
+end

--- a/src/RockBridge.hpp
+++ b/src/RockBridge.hpp
@@ -1,7 +1,7 @@
 //======================================================================================
-// Brazilian Institute of Robotics 
+// Brazilian Institute of Robotics
 // Authors: Thomio Watanabe
-//====================================================================================== 
+//======================================================================================
 #ifndef _ROCK_BRIDGE_HPP_
 #define _ROCK_BRIDGE_HPP_
 
@@ -28,7 +28,7 @@ namespace rock_gazebo
         public:
             // Pure virtual function implementation
             virtual void Load(int _argc = 0, char** _argv = NULL);
-            RockBridge(); 
+            RockBridge();
             ~RockBridge();
 
             typedef gazebo::physics::ModelPtr ModelPtr;
@@ -40,6 +40,7 @@ namespace rock_gazebo
             void setupTaskActivity(RTT::TaskContext* task);
 
             void processRockComponentsPlugin(sdf::ElementPtr pluginElement);
+            RTT::TaskContext* instanciateTask(sdf::ElementPtr taskElement);
             void instantiatePluginComponents( sdf::ElementPtr modelElement, ModelPtr model );
             void instantiateSensorComponents( sdf::ElementPtr modelElement, ModelPtr model );
 


### PR DESCRIPTION
Depend on:
- [ ] https://github.com/rock-gazebo/simulation-orogen-rock_gazebo/pull/24

This pull request defines a way to explicitely define which task should be deployed in relation to a given plugin, removing the need to hardcode plugins within this package (the way we did for underwater and thruster plugin).

README.md was modified to include the related documentation.