### PR TITLE
fix(test): attempt to fix flaky test

### DIFF
--- a/src/RockBridge.cpp
+++ b/src/RockBridge.cpp
@@ -235,6 +235,13 @@ RTT::TaskContext* RockBridge::instanciateTask(sdf::ElementPtr taskElement) {
 
 void RockBridge::setupTaskActivity(RTT::TaskContext* task)
 {
+    // Create and start sequential task activities
+    RTT::extras::SlaveActivity* activity =
+        new RTT::extras::SlaveActivity(task->engine());
+    activity->start();
+    activities.push_back(activity);
+    tasks.push_back(task);
+
     // Export the component interface on CORBA to Ruby access the component
     RTT::corba::TaskContextServer::Create( task );
 #if RTT_VERSION_GTE(2,8,99)
@@ -243,13 +250,6 @@ void RockBridge::setupTaskActivity(RTT::TaskContext* task)
 #else
     RTT::corba::CorbaDispatcher::Instance(task->ports(), ORO_SCHED_OTHER, RTT::os::LowestPriority);
 #endif
-
-    // Create and start sequential task activities
-    RTT::extras::SlaveActivity* activity =
-        new RTT::extras::SlaveActivity(task->engine());
-    activity->start();
-    activities.push_back(activity);
-    tasks.push_back(task);
 }
 
 // Callback method triggered every update begin


### PR DESCRIPTION
I'm randomly (and rarely) getting ComError in CI during
configuration of some sensor component - not always the
same one.

Publish the task on CORBA only after its activity is set.
It's a long shot - I have no idea whether it's the source
of the problem - but in any case it's better. Activities
should really not be changed while the task is being
manipulated.