### PR TITLE
fix(ruby): move include of InstanceRequirementsExtension to please yard

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit/instance_requirements_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/instance_requirements_extension.rb
@@ -16,9 +16,9 @@ module RockGazebo
                 end
                 self
             end
-
-            ::Syskit::InstanceRequirements.include InstanceRequirementsExtension
         end
+
+        ::Syskit::InstanceRequirements.include InstanceRequirementsExtension
     end
 end
 


### PR DESCRIPTION
Yard is failing without this patch (probably because it references
InstanceRequirementsExtension while it is being defined). This changes
nothing on the actual semantics of the code.