### PR TITLE
feat: add read_only attribute

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -57,7 +57,7 @@ module RockGazebo
 
         world.each_plugin do |plugin|
             if plugin.name == "rock_components"
-                setup_orogen_model_from_rock_components_plugin(plugin)
+                setup_orogen_model_from_rock_components_plugin(deployment, plugin)
             end
         end
 
@@ -71,7 +71,9 @@ module RockGazebo
     # @param [OroGen::Spec::Deployment] deployment the deployment model to modify
     # @param [SDF::Plugin] the plugin
     # @param [Float] period the task's period in seconds
-    def self.setup_orogen_model_from_components_plugin(deployment, plugin, period: 0.1)
+    def self.setup_orogen_model_from_rock_components_plugin(
+        deployment, plugin, period: 0.1
+    )
         plugin.xml.elements.each("task") do |el|
             deployment.task(el.attributes["name"], el.attributes["model"])
                       .periodic(period)

--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -87,7 +87,7 @@ module RockGazebo
             def use_gazebo_world(*path,
                                  world_name: nil,
                                  localhost: Conf.gazebo.localhost?,
-                                 read_only: [])
+                                 read_only: false)
                 world = use_sdf_world(*path, world_name: world_name)
                 deployment_model = ConfigurationExtension.world_to_orogen(world)
 
@@ -115,7 +115,7 @@ module RockGazebo
                 configured_deployment =
                     ::Syskit::Models::ConfiguredDeployment
                     .new(process_server_config.name, deployment_model,
-                         {}, "gazebo:#{world.name}", {}, read_only)
+                         {}, "gazebo:#{world.name}", {}, read_only: read_only)
                 register_configured_deployment(configured_deployment)
                 configured_deployment
             end

--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -75,14 +75,19 @@ module RockGazebo
                       "#{Roby.app.search_path.join(' ')}"
             end
 
-            # Sets up Syskit to use gazebo configured to use the given world
+            # Sets up Syskit to use gazebo configured to use the given world. One can set
+            # some of entities in the world as read only, meaning they won't be configured
+            # at startup, instead they will wait for another instance of syskit to do it.
+            # The `read_only` argument expects a string that is a part of the entity's
+            # name. If one wants to make all the entities read only, just set
+            # read_only: ["gazebo"]
             #
             # @return [Syskit::Deployment] a deployment object that represents
             #   gazebo itself
             def use_gazebo_world(*path,
                                  world_name: nil,
                                  localhost: Conf.gazebo.localhost?,
-                                 read_only: false)
+                                 read_only: [])
                 world = use_sdf_world(*path, world_name: world_name)
                 deployment_model = ConfigurationExtension.world_to_orogen(world)
 
@@ -145,7 +150,9 @@ module RockGazebo
             end
 
             def self.world_to_orogen(world)
-                ::Syskit::Deployment.new_submodel(name: "Deployment::Gazebo::#{world.name}") do
+                ::Syskit::Deployment.new_submodel(
+                    name: "Deployment::Gazebo::#{world.name}"
+                ) do
                     RockGazebo.setup_orogen_model_from_sdf_world(self, world)
                 end
             end

--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -79,7 +79,10 @@ module RockGazebo
             #
             # @return [Syskit::Deployment] a deployment object that represents
             #   gazebo itself
-            def use_gazebo_world(*path, world_name: nil, localhost: Conf.gazebo.localhost?)
+            def use_gazebo_world(*path,
+                                 world_name: nil,
+                                 localhost: Conf.gazebo.localhost?,
+                                 read_only: false)
                 world = use_sdf_world(*path, world_name: world_name)
                 deployment_model = ConfigurationExtension.world_to_orogen(world)
 
@@ -107,7 +110,7 @@ module RockGazebo
                 configured_deployment =
                     ::Syskit::Models::ConfiguredDeployment
                     .new(process_server_config.name, deployment_model,
-                         {}, "gazebo:#{world.name}", {})
+                         {}, "gazebo:#{world.name}", {}, read_only)
                 register_configured_deployment(configured_deployment)
                 configured_deployment
             end

--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -78,16 +78,17 @@ module RockGazebo
             # Sets up Syskit to use gazebo configured to use the given world. One can set
             # some of entities in the world as read only, meaning they won't be configured
             # at startup, instead they will wait for another instance of syskit to do it.
-            # The `read_only` argument expects a string that is a part of the entity's
-            # name. If one wants to make all the entities read only, just set
-            # read_only: ["gazebo"]
+            #
+            # @param [Boolean|#===|Array<#===>] read_only expects a string that is a part
+            # of the entity's name.
             #
             # @return [Syskit::Deployment] a deployment object that represents
             #   gazebo itself
             def use_gazebo_world(*path,
                                  world_name: nil,
                                  localhost: Conf.gazebo.localhost?,
-                                 read_only: false)
+                                 read_only: false,
+                                 logger_name: nil)
                 world = use_sdf_world(*path, world_name: world_name)
                 deployment_model = ConfigurationExtension.world_to_orogen(world)
 
@@ -115,7 +116,8 @@ module RockGazebo
                 configured_deployment =
                     ::Syskit::Models::ConfiguredDeployment
                     .new(process_server_config.name, deployment_model,
-                         {}, "gazebo:#{world.name}", {}, read_only: read_only)
+                         {}, "gazebo:#{world.name}", {}, read_only: read_only,
+                         logger_name: logger_name)
                 register_configured_deployment(configured_deployment)
                 configured_deployment
             end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-syskit/pull/325

This allows deploying a `ModelTask` as `read_only`, which enables using multiple `ModelTasks` simultaneously. To do so, one must run two separate instances of Syskit and set one of them as read_only through `Syskit.conf.use_gazebo_world("world", read_only: true)`