### PR TITLE
fix: process the tasks included in the SDF only when loading for simulation

### DIFF
--- a/bindings/ruby/bin/rock-gazebo
+++ b/bindings/ruby/bin/rock-gazebo
@@ -80,7 +80,7 @@ Rock::Gazebo.download_missing_models(scene)
 
 if parse_sdf_only
     args.each do |path|
-        xml = Rock::Gazebo.process_sdf_world(path)
+        xml = Rock::Gazebo.process_gazebo_file(path)
         xml.write(STDOUT, 2)
     end
     exit 0


### PR DESCRIPTION
We otherwise need to have them installed when using the SDF as a model of the vehicle in production.