### PR TITLE
feat: record all exported links and joints

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -104,6 +104,19 @@ module RockGazebo
                 end
             end
 
+            # Registers a device as one of the exported joint devices
+            def register_exported_joint_device(dev)
+                @exported_joints ||= []
+                @exported_joints << dev
+            end
+
+            # Iterate over exported joints
+            def each_exported_joint
+                return enum_for(__method__) unless block_given?
+
+                @exported_joints&.each { yield _1 }
+            end
+
             # Create a device that provides access to a subset of the joints
             #
             # Use it for instance, to get a simulated actuator
@@ -125,8 +138,23 @@ module RockGazebo
                 driver_def.add_models([driver_m])
                 driver_def.select_service(driver_srv)
 
-                device(CommonModels::Devices::Gazebo::Joint,
-                       as: as, using: driver_def)
+                dev = device(CommonModels::Devices::Gazebo::Joint,
+                             as: as, using: driver_def)
+                register_exported_joint_device(dev)
+                dev
+            end
+
+            # Registers a device as one of the exported link devices
+            def register_exported_link_device(dev)
+                @exported_links ||= []
+                @exported_links << dev
+            end
+
+            # Iterate over exported links
+            def each_exported_link
+                return enum_for(__method__) unless block_given?
+
+                @exported_links&.each { yield _1 }
             end
 
             # Setup a link export feature of rock_gazebo::ModelTask
@@ -177,6 +205,7 @@ module RockGazebo
                 dev = device(CommonModels::Devices::Gazebo::Link,
                              as: as, using: link_driver)
                 dev.frame_transform(from_frame => to_frame) if from_frame != to_frame
+                register_exported_link_device(dev)
                 dev
             end
 

--- a/bindings/ruby/test/syskit/test_robot_definition_extension.rb
+++ b/bindings/ruby/test/syskit/test_robot_definition_extension.rb
@@ -428,6 +428,10 @@ module RockGazebo
                     assert_equal 'some_links',
                                  srv.link_state_samples_port.to_actual_port.name
                 end
+
+                it "records all the exported links" do
+                    assert_equal [@link_device], @robot_model.each_exported_link.to_a
+                end
             end
 
             describe '#sdf_export_joint' do
@@ -488,6 +492,10 @@ module RockGazebo
                     )
                     srv = joint_device.to_instance_requirements.instanciate(plan)
                     assert srv.model.dynamic_service_options[:position_offsets]
+                end
+
+                it "records all the exported joints" do
+                    assert_equal [@joint_device], @robot_model.each_exported_joint.to_a
                 end
             end
         end


### PR DESCRIPTION
This makes it easier to interact specifically with links or joints that were exported via an sdf_export_* call. For example, it simplifies how one would start these exported joints/links to make sure a read_only ModelTask doesnt get reconfigured.