### PR TITLE
fix: use correct process manager when registering process server

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/configuration_extension.rb
@@ -105,7 +105,7 @@ module RockGazebo
                         )
                     else
                         ::Syskit.conf.register_process_server(
-                            "gazebo", ::Syskit::RobyApp::UnmanagedTasksManager.new,
+                            "gazebo", ::Syskit::ProcessManagers::Unmanaged::Manager.new,
                             app.log_dir, **options
                         )
                     end


### PR DESCRIPTION
The UnmanagedTasksManager was refactored in this PR:
https://github.com/rock-core/tools-syskit/pull/424/files#diff-40968482ce7a15ccad4148167ae627ec487f504a3f69ba0fa79a5e079879bb4b

Now it has a different path