### PR TITLE
fix: correct handling of plugins in recursive models

### DIFF
--- a/bindings/ruby/bin/rock-gazebo
+++ b/bindings/ruby/bin/rock-gazebo
@@ -80,8 +80,8 @@ Rock::Gazebo.download_missing_models(scene)
 
 if parse_sdf_only
     args.each do |path|
-        xml = Rock::Gazebo.process_gazebo_file(path)
-        xml.write(STDOUT, 2)
+        root = Rock::Gazebo.process_gazebo_file(path)
+        root.xml.write(STDOUT, 2)
     end
     exit 0
 end

--- a/bindings/ruby/lib/rock/gazebo.rb
+++ b/bindings/ruby/lib/rock/gazebo.rb
@@ -187,7 +187,9 @@ module Rock
         #   within this plugin need
         def self.process_gazebo_plugin(world, plugin_xml, loader:)
             scope = resolve_plugin_full_name(world.xml, plugin_xml)
-            normalize_rock_components(scope, plugin_xml, loader)
+            typekits = normalize_rock_components(scope, plugin_xml, loader)
+            plugin_xml.attributes["name"] = scope.gsub(/[^\w]/, "_")
+            typekits
         rescue OroGen::NotFound => e
             plugin_name = plugin_xml.attributes["name"]
             raise e, "while processing the <task ..> elements of the #{plugin_name} "\

--- a/bindings/ruby/lib/rock/gazebo.rb
+++ b/bindings/ruby/lib/rock/gazebo.rb
@@ -187,9 +187,7 @@ module Rock
         #   within this plugin need
         def self.process_gazebo_plugin(world, plugin_xml, loader:)
             scope = resolve_plugin_full_name(world.xml, plugin_xml)
-            typekits = normalize_rock_components(scope, plugin_xml, loader)
-            plugin_xml.attributes["name"] = scope.gsub(/[^\w]/, "_")
-            typekits
+            normalize_rock_components(scope, plugin_xml, loader)
         rescue OroGen::NotFound => e
             plugin_name = plugin_xml.attributes["name"]
             raise e, "while processing the <task ..> elements of the #{plugin_name} "\

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -28,7 +28,8 @@ module RockGazebo
 
     PLUGIN_TASK_MODELS = {
         /gazebo_thruster/ => "rock_gazebo::ThrusterTask",
-        /gazebo_underwater/ => "rock_gazebo::UnderwaterTask"
+        /gazebo_underwater/ => "rock_gazebo::UnderwaterTask",
+        /gazebo_gps/ => "rock_gazebo::GPSTask"
     }.freeze
 
     # Add tasks to a deployment, matching the tasks that would be deployed by

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -28,8 +28,7 @@ module RockGazebo
 
     PLUGIN_TASK_MODELS = {
         /gazebo_thruster/ => "rock_gazebo::ThrusterTask",
-        /gazebo_underwater/ => "rock_gazebo::UnderwaterTask",
-        /gazebo_gps/ => "rock_gazebo::GPSTask"
+        /gazebo_underwater/ => "rock_gazebo::UnderwaterTask"
     }.freeze
 
     # Add tasks to a deployment, matching the tasks that would be deployed by

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -124,7 +124,7 @@ module RockGazebo
             )
         end
 
-        model.each_plugin do |plugin|
+        model.each_direct_plugin do |plugin|
             setup_orogen_model_from_sdf_model_plugin(
                 deployment, plugin,
                 prefix: prefix,

--- a/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
+++ b/bindings/ruby/lib/rock_gazebo/orogen_model_from_sdf_world.rb
@@ -132,7 +132,7 @@ module RockGazebo
             )
         end
 
-        model.each_model do |submodel|
+        model.each_direct_model do |submodel|
             setup_orogen_submodel_from_sdf_model(
                 deployment, submodel,
                 prefix: "#{prefix}#{submodel.name}::",

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -113,13 +113,6 @@ module RockGazebo
                             as: device_name,
                             using: OroGen.rock_gazebo.UnderwaterTask
                         )
-                    when "rock_gazebo::GPSTask"
-                        require "common_models/models/devices/gazebo/gps"
-                        return device(
-                            CommonModels::Devices::Gazebo::GPS,
-                            as: device_name,
-                            using: OroGen.rock_gazebo.GPSTask
-                        )
                     end
                 end
                 return if has_task
@@ -135,11 +128,6 @@ module RockGazebo
                     device(CommonModels::Devices::Gazebo::Underwater,
                            as: device_name,
                            using: OroGen.rock_gazebo.UnderwaterTask)
-                when /gazebo_gps/
-                    require "common_models/models/devices/gazebo/gps"
-                    device(CommonModels::Devices::Gazebo::gps,
-                           as: device_name,
-                           using: OroGen.rock_gazebo.GPSTask)
                 end
             end
 

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -86,7 +86,7 @@ module RockGazebo
             #   rock-gazebo plugin or by the syskit integration (yet), or the
             #   device model and device driver that should be used for this
             #   sensor
-            def plugins_to_device(plugin, device_name)
+            def plugins_to_device(plugin, device_name, deployment_hint)
                 has_task = false
                 plugin.xml.elements.to_a("task").each do |task_element|
                     task_model_name = task_element.attributes["model"]
@@ -123,13 +123,13 @@ module RockGazebo
                     device(CommonModels::Devices::Gazebo::Thruster,
                            as: device_name,
                            using: OroGen.rock_gazebo.ThrusterTask)
-                        .prefer_deployed_tasks(task_name)
+                        .prefer_deployed_tasks(deployment_hint)
                 when /gazebo_underwater/
                     require "common_models/models/devices/gazebo/underwater"
                     device(CommonModels::Devices::Gazebo::Underwater,
                            as: device_name,
                            using: OroGen.rock_gazebo.UnderwaterTask)
-                        .prefer_deployed_tasks(task_name)
+                        .prefer_deployed_tasks(deployment_hint)
                 end
             end
 
@@ -596,7 +596,9 @@ module RockGazebo
                     device_name = "#{normalize_name(model_name)}_#{device_name}"
                 end
 
-                device = plugins_to_device(plugin, device_name)
+                deployment_hint =
+                    "#{deployment_prefix}#{sdf_relative_path(sdf_model, plugin)}"
+                device = plugins_to_device(plugin, device_name, deployment_hint)
 
                 unless device
                     RockGazebo.warn(

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -81,6 +81,12 @@ module RockGazebo
             # Given a gazebo plugin, returns the device and device driver model that
             # should be used to handle it
             #
+            # @param plugin [Plugin]
+            # @param device_name [String] The desired device name
+            # @param deployment_hint [String] The deployment hint for each of the tasks,
+            #   this must be created using the using the desired `deployment_prefix`
+            #   and the `relative_path` to the plugin.
+            #
             # @return [nil,(Model<Syskit::Device>,Model<Syskit::Component>)]
             #   either nil if this type of sensor is not handled either by the
             #   rock-gazebo plugin or by the syskit integration (yet), or the
@@ -91,6 +97,8 @@ module RockGazebo
                 plugin.xml.elements.to_a("task").each do |task_element|
                     task_model_name = task_element.attributes["model"]
                     task_model = ::Syskit::TaskContext.find_model_from_orogen_name(task_model_name)
+                    # The task name is used to avoid ambiguity between multiple plugins
+                    # originated from the same plugin.
                     task_name = task_element.attributes["name"]
                     if (device = RobotDefinitionExtension.plugin_device_mappings[task_model])
                         return device(device, as: device_name, using: task_model)

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -105,14 +105,14 @@ module RockGazebo
                             CommonModels::Devices::Gazebo::Thruster,
                             as: device_name,
                             using: OroGen.rock_gazebo.ThrusterTask
-                        )
+                        ).prefer_deployed_tasks(task_name)
                     when "rock_gazebo::UnderwaterTask"
                         require "common_models/models/devices/gazebo/underwater"
                         return device(
                             CommonModels::Devices::Gazebo::Underwater,
                             as: device_name,
                             using: OroGen.rock_gazebo.UnderwaterTask
-                        )
+                        ).prefer_deployed_tasks(task_name)
                     end
                 end
                 return if has_task
@@ -123,11 +123,13 @@ module RockGazebo
                     device(CommonModels::Devices::Gazebo::Thruster,
                            as: device_name,
                            using: OroGen.rock_gazebo.ThrusterTask)
+                        .prefer_deployed_tasks(task_name)
                 when /gazebo_underwater/
                     require "common_models/models/devices/gazebo/underwater"
                     device(CommonModels::Devices::Gazebo::Underwater,
                            as: device_name,
                            using: OroGen.rock_gazebo.UnderwaterTask)
+                        .prefer_deployed_tasks(task_name)
                 end
             end
 
@@ -594,9 +596,7 @@ module RockGazebo
                     device_name = "#{normalize_name(model_name)}_#{device_name}"
                 end
 
-                device = plugins_to_device(
-                    plugin, device_name
-                )
+                device = plugins_to_device(plugin, device_name)
 
                 unless device
                     RockGazebo.warn(
@@ -606,11 +606,7 @@ module RockGazebo
                     return
                 end
                 device.doc "Gazebo: #{plugin_name} plugin of #{sdf_model.full_name}"
-
-                relative = sdf_relative_path(sdf_model, plugin)
-                device
-                    .sdf(plugin)
-                    .prefer_deployed_tasks("#{deployment_prefix}#{relative}")
+                device.sdf(plugin)
             end
 
             def sdf_relative_path(from, to)

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -589,8 +589,8 @@ module RockGazebo
                 device_name = "#{plugin_name}_plugin"
                 if prefix_device_with_name
                     if Syskit.scope_device_name_with_links_and_submodels
-                        path = sdf_relative_path(sdf_model, plugin)
-                        device_name = "#{normalize_name(path)}_plugin"
+                        path = sdf_relative_path(sdf_model, plugin.parent)
+                        device_name = "#{normalize_name(path)}#{plugin_name}_plugin"
                     end
 
                     device_name = "#{normalize_name(model_name)}_#{device_name}"

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -458,6 +458,13 @@ module RockGazebo
                         sdf_model.each_plugin
                     end
 
+                models =
+                    if Syskit.scope_device_name_with_links_and_submodels
+                        sdf_model.each_direct_model
+                    else
+                        sdf_model.each_model
+                    end
+
                 sensors.each do |sensor|
                     gazebo_define_sensor_device(
                         sdf_model, sensor,
@@ -476,12 +483,12 @@ module RockGazebo
                     )
                 end
 
-                sdf_model.each_model do |sdf_submodel|
+                models.each do |model|
                     load_gazebo_robot_submodels(
-                        sdf_submodel,
-                        name: name + "_" + sdf_submodel.name,
+                        model,
+                        name: name + "_" + model.name,
                         prefix_device_with_name: true,
-                        deployment_prefix: deployment_prefix + sdf_submodel.name + "::"
+                        deployment_prefix: deployment_prefix + model.name + "::"
                     )
                 end
             end

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -113,6 +113,13 @@ module RockGazebo
                             as: device_name,
                             using: OroGen.rock_gazebo.UnderwaterTask
                         )
+                    when "rock_gazebo::GPSTask"
+                        require "common_models/models/devices/gazebo/gps"
+                        return device(
+                            CommonModels::Devices::Gazebo::GPS,
+                            as: device_name,
+                            using: OroGen.rock_gazebo.GPSTask
+                        )
                     end
                 end
                 return if has_task
@@ -128,6 +135,11 @@ module RockGazebo
                     device(CommonModels::Devices::Gazebo::Underwater,
                            as: device_name,
                            using: OroGen.rock_gazebo.UnderwaterTask)
+                when /gazebo_gps/
+                    require "common_models/models/devices/gazebo/gps"
+                    device(CommonModels::Devices::Gazebo::gps,
+                           as: device_name,
+                           using: OroGen.rock_gazebo.GPSTask)
                 end
             end
 

--- a/bindings/ruby/test/models/simple_model/model.sdf
+++ b/bindings/ruby/test/models/simple_model/model.sdf
@@ -11,5 +11,8 @@
           <axis>
           </axis>
       </joint>
+      <plugin name="gps_test">
+        <task model="rock_gazebo::GPSTask"/>
+      </plugin>
   </model>
 </sdf>

--- a/bindings/ruby/test/syskit/test_robot_definition_extension.rb
+++ b/bindings/ruby/test/syskit/test_robot_definition_extension.rb
@@ -73,12 +73,11 @@ module RockGazebo
             describe 'sensor model' do
                 describe "prefix_device_with_name: false" do
                     before do
-                        @world = ::SDF::Root.load(
-                            expand_fixture_world('attached_simple_model.world'),
-                            flatten: false
-                        ).each_world.first
+                        @world = load_normalized_world("attached_simple_model.world")
                         @robot_sdf = @world.each_model.first
-                        @robot_model.load_gazebo(@robot_sdf, 'gazebo::test')
+                        @robot_model.load_gazebo(
+                            @robot_sdf, "gazebo::test", prefix_device_with_name: false
+                        )
                     end
 
                     it "defines a sensor device based on the sensor name only" do
@@ -110,13 +109,10 @@ module RockGazebo
                     end
                     describe "loading the root model" do
                         before do
-                            @world = ::SDF::Root.load(
-                                expand_fixture_world('attached_simple_model.world'),
-                                flatten: false
-                            ).each_world.first
+                            @world = load_normalized_world("attached_simple_model.world")
                             @robot_sdf = @world.each_model.first
                             @robot_model.load_gazebo(
-                                @robot_sdf, 'gazebo::test', prefix_device_with_name: true
+                                @robot_sdf, "gazebo::test", prefix_device_with_name: true
                             )
                         end
 
@@ -143,15 +139,11 @@ module RockGazebo
 
                     describe "loading a submodel" do
                         before do
-                            @world = ::SDF::Root.load(
-                                expand_fixture_world('attached_simple_model.world'),
-                                flatten: false
-                            ).each_world.first
+                            @world = load_normalized_world("attached_simple_model.world")
                             @root_model_sdf = @world.each_model.first
                             @robot_sdf = @root_model_sdf.each_model.first
                             @robot_model.load_gazebo(
-                                @robot_sdf, 'gazebo::test',
-                                prefix_device_with_name: true
+                                @robot_sdf, "gazebo::test", prefix_device_with_name: true
                             )
                         end
 
@@ -189,13 +181,10 @@ module RockGazebo
 
                     describe "loading the root model" do
                         before do
-                            @world = ::SDF::Root.load(
-                                expand_fixture_world('attached_simple_model.world'),
-                                flatten: false
-                            ).each_world.first
+                            @world = load_normalized_world("attached_simple_model.world")
                             @robot_sdf = @world.each_model.first
                             @robot_model.load_gazebo(
-                                @robot_sdf, 'gazebo::test', prefix_device_with_name: true
+                                @robot_sdf, "gazebo::test", prefix_device_with_name: true
                             )
                         end
 
@@ -226,15 +215,11 @@ module RockGazebo
 
                     describe "loading a submodel" do
                         before do
-                            @world = ::SDF::Root.load(
-                                expand_fixture_world('attached_simple_model.world'),
-                                flatten: false
-                            ).each_world.first
+                            @world = load_normalized_world("attached_simple_model.world")
                             @root_model_sdf = @world.each_model.first
                             @robot_sdf = @root_model_sdf.each_model.first
                             @robot_model.load_gazebo(
-                                @robot_sdf, 'gazebo::test',
-                                prefix_device_with_name: true
+                                @robot_sdf, "gazebo::test", prefix_device_with_name: true
                             )
                         end
 

--- a/bindings/ruby/test/syskit/test_robot_definition_extension.rb
+++ b/bindings/ruby/test/syskit/test_robot_definition_extension.rb
@@ -262,76 +262,194 @@ module RockGazebo
                     end
                 end
 
-                describe "prefix_device_with_name: true and " \
-                         "scope_device_name_with_links_and_submodels" do
-                end
-            end
+                describe "plugin model" do
+                    require "common_models/models/devices/gazebo/gps"
 
-            describe 'plugin model' do
-                describe "prefix_device_with_name: true and " \
-                         "!scope_device_name_with_links_and_submodels" do
                     before do
-                        @__scope_flag = Syskit.scope_device_name_with_links_and_submodels
-                        Syskit.scope_device_name_with_links_and_submodels = false
-
+                        @task_model = OroGen.rock_gazebo.GPSTask
+                        RockGazebo::Syskit::RobotDefinitionExtension
+                            .register_device_by_plugin_task_model(
+                                @task_model, CommonModels::Devices::Gazebo::GPS
+                            )
                     end
 
-                    after do
-                        Syskit.scope_device_name_with_links_and_submodels = @__scope_flag
-                    end
-
-                    describe "loading the submodel" do
+                    describe "prefix_device_with_name: false" do
                         before do
-                            @robot_sdf =
-                                ::SDF::Root.load(
-                                    'model://model_with_plugin', flatten: false
-                                ).each_model.first
-                            @robot_model.load_gazebo(
-                                    @robot_sdf, 'gazebo', name: 'renamed_model'
+                            @world = load_normalized_world("attached_simple_model.world")
+                            @robot_sdf = @world.each_model.first
+                            @robot_model.load_gazebo(@robot_sdf, "gazebo::test")
+                        end
+
+                        it "defines a plugin device based on the plugin name only" do
+                            assert @robot_model.find_device("gps_test_plugin")
+                        end
+
+                        it "attaches the plugin device to an existing deployment" do
+                            device = @robot_model.find_device("gps_test_plugin")
+                            hint = device.to_instance_requirements.deployment_hints.first
+                            deployment_m = RockGazebo.orogen_model_from_sdf_world(
+                                "gazebo", @world
+                            )
+                            assert_equal "gazebo::test::attachment::included_model::gps_test",
+                                         hint
+                            assert deployment_m.find_task_by_name(hint),
+                                   "hint is #{hint}, available deployments: " \
+                                   "#{deployment_m.each_task.map(&:name).sort.join(', ')}"
+                        end
+                    end
+
+                    describe "prefix_device_with_name: true and " \
+                             "!scope_device_name_with_links_and_submodels" do
+                        before do
+                            @__scope_flag = Syskit.scope_device_name_with_links_and_submodels
+                            Syskit.scope_device_name_with_links_and_submodels = false
+                        end
+
+                        after do
+                            Syskit.scope_device_name_with_links_and_submodels = @__scope_flag
+                        end
+
+                        describe "loading the root model" do
+                            before do
+                                @world = load_normalized_world("attached_simple_model.world")
+                                @robot_sdf = @world.each_model.first
+                                @robot_model.load_gazebo(
+                                    @robot_sdf, "gazebo::test", prefix_device_with_name: true
                                 )
-                            @plugin = @robot_sdf.each_plugin.first
-                            @device = @robot_model.find_device('g_sensor').model
-                            @task_model = OroGen.rock_gazebo.GPSTask
+                            end
+
+                            it "defines a plugin device based on the root model " \
+                               "and sensor name" do
+                                assert @robot_model.find_device("attachment_gps_test_plugin")
+                            end
+
+                            it "attaches the plugin device to an existing deployment" do
+                                device =
+                                    @robot_model.find_device("attachment_gps_test_plugin")
+                                hint = device.to_instance_requirements.deployment_hints.first
+                                deployment_m =
+                                    RockGazebo.orogen_model_from_sdf_world("gazebo", @world)
+                                assert_equal(
+                                    "gazebo::test::attachment::included_model::gps_test",
+                                    hint
+                                )
+                                assert deployment_m.find_task_by_name(hint),
+                                       "hint is #{hint}, available deployments: " \
+                                       "#{deployment_m.each_task.map(&:name).sort.join(', ')}"
+                            end
                         end
 
-                        it "registers device to a task model defined by a plugin" do
-                            RockGazebo::Syskit::RobotDefinitionExtension
-                                .register_device_by_plugin_task_model(@task_model, @device)
-                            registered_device = @robot_model
-                                                .plugins_to_device(@plugin, "gps_test")
-                            assert_equal @robot_model.devices["gps_test"], registered_device
-                            assert_equal registered_device.requirements,
-                                        @task_model.with_arguments(gps_dev: registered_device)
+                        describe "loading a submodel" do
+                            before do
+                                @world = load_normalized_world("attached_simple_model.world")
+                                @root_model_sdf = @world.each_model.first
+                                @robot_sdf = @root_model_sdf.each_model.first
+                                @robot_model.load_gazebo(
+                                    @robot_sdf, "gazebo::test", prefix_device_with_name: true
+                                )
+                            end
+
+                            it "defines a plugin device based on the root model " \
+                               "and sensor name" do
+                                device = @robot_model
+                                         .find_device("included_model_gps_test_plugin")
+                                assert device
+                            end
+
+                            it "attaches the plugin device to an existing deployment" do
+                                device =
+                                    @robot_model.find_device("included_model_gps_test_plugin")
+                                hint = device.to_instance_requirements.deployment_hints.first
+                                deployment_m = RockGazebo.orogen_model_from_sdf_world(
+                                    "gazebo", @world
+                                )
+                                assert_equal(
+                                    "gazebo::test::attachment::included_model::gps_test",
+                                    hint
+                                )
+                                assert deployment_m.find_task_by_name(hint),
+                                       "hint is #{hint}, available deployments: " \
+                                       "#{deployment_m.each_task.map(&:name).sort.join(', ')}"
+                            end
                         end
                     end
-                end
-                describe "prefix_device_with_name: true and " \
-                         "scope_device_name_with_links_and_submodels" do
-                    before do
-                        @__scope_flag = Syskit.scope_device_name_with_links_and_submodels
-                        Syskit.scope_device_name_with_links_and_submodels = true
-                    end
+                    describe "prefix_device_with_name: true and " \
+                             "scope_device_name_with_links_and_submodels" do
+                        before do
+                            @__scope_flag = Syskit.scope_device_name_with_links_and_submodels
+                            Syskit.scope_device_name_with_links_and_submodels = true
+                            @world = load_normalized_world("attached_simple_model.world")
+                        end
 
-                    after do
-                        Syskit.scope_device_name_with_links_and_submodels = @__scope_flag
-                    end
+                        after do
+                            Syskit.scope_device_name_with_links_and_submodels = @__scope_flag
+                        end
 
-                    before do
-                        @world = ::SDF::Root.load(
-                            expand_fixture_world('attached_model_with_plugin.world'),
-                            flatten: false
-                        ).each_world.first
-                        @robot_sdf = @world.each_model.first
-                        @robot_model.load_gazebo(
-                            @robot_sdf, 'gazebo::test', prefix_device_with_name: true
-                        )
-                    end
+                        describe "loading the root model" do
+                            before do
+                                @robot_sdf = @world.each_model.first
+                                @robot_model.load_gazebo(
+                                    @robot_sdf, "gazebo::test", prefix_device_with_name: true
+                                )
+                            end
 
-                    it "defines a plugin device based on the root model " \
-                        "and plugin name" do
-                        assert @robot_model.find_device(
-                            "attachment_included_model_gps_test_plugin"
-                        )
+                            it "defines a plugin device based on the root model " \
+                               "and sensor name" do
+                                assert @robot_model.find_device(
+                                    "attachment_included_model_gps_test_plugin"
+                                )
+                            end
+
+                            it "attaches the plugin device to an existing deployment" do
+                                device = @robot_model.find_device(
+                                    "attachment_included_model_gps_test_plugin"
+                                )
+                                hint = device.to_instance_requirements.deployment_hints.first
+                                deployment_m = RockGazebo.orogen_model_from_sdf_world(
+                                    "gazebo", @world
+                                )
+                                assert_equal(
+                                    "gazebo::test::attachment::included_model::gps_test",
+                                    hint
+                                )
+                                assert deployment_m.find_task_by_name(hint),
+                                       "hint is #{hint}, available deployments: " \
+                                       "#{deployment_m.each_task.map(&:name).sort.join(', ')}"
+                            end
+                        end
+
+                        describe "loading a submodel" do
+                            before do
+                                @root_model_sdf = @world.each_model.first
+                                @robot_sdf = @root_model_sdf.each_model.first
+                                @robot_model.load_gazebo(
+                                    @robot_sdf, "gazebo::test", prefix_device_with_name: true
+                                )
+                            end
+
+                            it "defines a plugin device based on the root model " \
+                               "and sensor name" do
+                                assert \
+                                    @robot_model.find_device("included_model_gps_test_plugin")
+                            end
+
+                            it "attaches the plugin device to an existing deployment" do
+                                device = @robot_model.find_device(
+                                    "included_model_gps_test_plugin"
+                                )
+                                hint = device.to_instance_requirements.deployment_hints.first
+                                deployment_m = RockGazebo.orogen_model_from_sdf_world(
+                                    "gazebo", @world
+                                )
+                                assert_equal(
+                                    "gazebo::test::attachment::included_model::gps_test",
+                                    hint
+                                )
+                                assert deployment_m.find_task_by_name(hint),
+                                       "hint is #{hint}, available deployments: " \
+                                       "#{deployment_m.each_task.map(&:name).sort.join(', ')}"
+                            end
+                        end
                     end
                 end
             end
@@ -821,6 +939,13 @@ module RockGazebo
                                  ir.arguments.values
                     end
                 end
+            end
+
+            def load_normalized_world(world)
+                world = ::SDF::Root.load(expand_fixture_world(world), flatten: false)
+                                   .each_world.first
+                Rock::Gazebo.process_gazebo_world(world)
+                world
             end
         end
     end

--- a/bindings/ruby/test/worlds/attached_model_with_plugin.world
+++ b/bindings/ruby/test/worlds/attached_model_with_plugin.world
@@ -1,0 +1,11 @@
+<sdf version="1.6">
+    <world name="test">
+        <model name="attachment">
+            <include>
+                <name>included_model</name>
+                <uri>model://model_with_plugin</uri>
+            </include>
+        </model>
+    </world>
+</sdf>
+


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-control/control-ruby_sdformat/pull/35

Based on: https://github.com/rock-gazebo/simulation-rock_gazebo/pull/60

The plugin devices are not scoped by their models,
and are defined at every level of the model hierarchy
instead of only at the last one. Given the impact of
that change this will share the flag from the sensors fix,
the new correct behaviour needs to be enabled by setting
RockGazebo::Syskit.scope_device_name_with_links_and_submodels.