### PR TITLE
chore: cleanup "feature flags" on the syskit part of the package

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit.rb
@@ -13,6 +13,7 @@ require 'models/devices/gazebo/joint'
 require 'transformer/syskit'
 Transformer::SyskitPlugin.enable
 require 'transformer/sdf'
+require 'rock_gazebo/syskit/features'
 require 'rock_gazebo/syskit/sdf'
 require 'rock_gazebo/syskit/configuration_extension'
 require 'rock_gazebo/syskit/profile_extension'

--- a/bindings/ruby/lib/rock_gazebo/syskit/features.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/features.rb
@@ -1,0 +1,47 @@
+module RockGazebo
+    module Syskit
+        class << self
+            # Feature flag that corrects how the library generates sensor device names
+            #
+            # When recursive models are used, the library's old behaviour is to
+            # define sensor devices with the root model name and the sensor name,
+            # that is
+            #
+            #     use_gazebo_model model://model_in_model
+            #
+            # will define 'root_gps_sensor' if the XML hierarchy is
+            # root/included_model/link/gps. It will also define
+            # root_included_model_gps_sensor along the way
+            #
+            # This rather obviously starts failing when one wants to include
+            # the same sub-model more than once, or have two sensors of the
+            # same type in the model (the latter could be worked around by
+            # changing the sensor name though)
+            #
+            # This historical behaviour is retained when the flag is false (
+            # this is the default). The new behaviour is to properly scope
+            # sensors by the full path in the XML. In the example above,
+            # the sensor device is root_included_model_link_gps_sensor_dev
+            attr_accessor :scope_device_name_with_links_and_submodels
+
+            # Feature flag that toggles the automatic definition of links when
+            # loading a gazebo model.
+            #
+            # This starts failing when one uses more than two levels of submodels as it
+            # quickly gets too complex to manage the automatically generated links names
+            attr_accessor :use_gazebo_automatic_links
+
+            # Feature flag that control use_gazebo_world and use_gazebo_model's
+            # prefix_device_with_name flag.
+            #
+            # The historical default was false, but you really should switch it to true.
+            # First migrate little by little each call and then turn it on globally
+            # by setting this flag.
+            attr_accessor :prefix_device_with_name
+        end
+
+        @scope_device_name_with_links_and_submodels = false
+        @use_gazebo_automatic_links = true
+        @prefix_device_with_name = false
+    end
+end

--- a/bindings/ruby/lib/rock_gazebo/syskit/profile_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/profile_extension.rb
@@ -141,14 +141,20 @@ module RockGazebo
             #
             # @param [Boolean] use_world whether {#use_gazebo_world} should be
             #   called at the end. You usually want this
-            def use_gazebo_model(*path, filter: nil, as: nil, use_world: true, reuse: nil, prefix_device_with_name: nil)
+            def use_gazebo_model(
+                *path,
+                filter: nil, as: nil, use_world: true,
+                reuse: nil, prefix_device_with_name: Syskit.prefix_device_with_name
+            )
                 use_sdf_model(*path, as: as, filter: filter)
                 model_in_world = resolve_model_in_world
 
                 # Load the model in the syskit subsystems
-                robot.load_gazebo(model_in_world, "gazebo::#{sdf_world.name}",
-                                  reuse: reuse,
-                                  prefix_device_with_name: prefix_device_with_name)
+                robot.load_gazebo(
+                    model_in_world, "gazebo::#{sdf_world.name}",
+                    reuse: reuse,
+                    prefix_device_with_name: prefix_device_with_name
+                )
 
                 use_gazebo_world(reuse: reuse) if use_world
             end

--- a/bindings/ruby/lib/rock_gazebo/syskit/profile_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/profile_extension.rb
@@ -18,29 +18,34 @@ module RockGazebo
             def resolve_sdf_model(*path)
                 if path.size == 1 && !path.first.respond_to?(:to_str)
                     # Assume this is a SDF::Model object
-                    path.first
-                else
-                    _, resolved_paths = Rock::Gazebo.resolve_worldfiles_and_models_arguments(
-                        [File.join(*path)], path_resolver: Roby.app
-                    )
-                    full_path = resolved_paths.first
-                    if !File.file?(full_path)
-                        if File.file?(File.join(full_path, 'model.config'))
-                            full_path = ::SDF::XML.model_path_of(full_path)
-                        else
-                            raise ArgumentError, "#{full_path} cannot be resolved to a valid SDF file"
-                        end
-                    end
-
-                    sdf = ::SDF::Root.load(full_path, flatten: false)
-                    models = sdf.each_model.to_a
-                    if models.size > 1
-                        raise ArgumentError, "#{full_path} has more than one top level model, cannot use in use_sdf_model"
-                    elsif models.empty?
-                        raise ArgumentError, "#{full_path} has no top level model, cannot use in use_sdf_model"
-                    end
-                    return sdf
+                    return path.first
                 end
+
+                _, resolved_paths = Rock::Gazebo.resolve_worldfiles_and_models_arguments(
+                    [File.join(*path)], path_resolver: Roby.app
+                )
+                full_path = resolved_paths.first
+                unless File.file?(full_path)
+                    if File.file?(File.join(full_path, "model.config"))
+                        full_path = ::SDF::XML.model_path_of(full_path)
+                    else
+                        raise ArgumentError,
+                              "#{full_path} cannot be resolved to a valid SDF file"
+                    end
+                end
+
+                sdf = ::SDF::Root.load(full_path, flatten: false)
+                models = sdf.each_model.to_a
+                if models.size > 1
+                    raise ArgumentError,
+                          "#{full_path} has more than one top level model, " \
+                          "cannot use in use_sdf_model"
+                elsif models.empty?
+                    raise ArgumentError,
+                          "#{full_path} has no top level model, " \
+                          "cannot use in use_sdf_model"
+                end
+                sdf
             end
 
             class AlreadyLoaded < ArgumentError; end
@@ -50,7 +55,9 @@ module RockGazebo
             # @return [Model]
             def use_sdf_model(*path, filter: nil, as: nil)
                 if @sdf
-                    raise AlreadyLoaded, "SDF model already loaded, loading more than one is not possible"
+                    raise AlreadyLoaded,
+                          "SDF model already loaded, " \
+                          "loading more than one is not possible"
                 end
 
                 # This is a guard used by

--- a/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/robot_definition_extension.rb
@@ -2,50 +2,6 @@
 
 module RockGazebo
     module Syskit
-        class << self
-            # Feature flag that corrects how the library generates sensor device names
-            #
-            # When recursive models are used, the library's old behaviour is to
-            # define sensor devices with the root model name and the sensor name,
-            # that is
-            #
-            #     use_gazebo_model model://model_in_model
-            #
-            # will define 'root_gps_sensor' if the XML hierarchy is
-            # root/included_model/link/gps. It will also define
-            # root_included_model_gps_sensor along the way
-            #
-            # This rather obviously starts failing when one wants to include
-            # the same sub-model more than once, or have two sensors of the
-            # same type in the model (the latter could be worked around by
-            # changing the sensor name though)
-            #
-            # This historical behaviour is retained when the flag is false (
-            # this is the default). The new behaviour is to properly scope
-            # sensors by the full path in the XML. In the example above,
-            # the sensor device is root_included_model_link_gps_sensor_dev
-            attr_accessor :scope_device_name_with_links_and_submodels
-
-            # Feature flag that toggles the automatic definition of links when
-            # loading a gazebo model.
-            #
-            # This starts failing when one uses more than two levels of submodels as it
-            # quickly gets too complex to manage the automatically generated links names
-            attr_accessor :use_gazebo_automatic_links
-
-            # Feature flag that control use_gazebo_world and use_gazebo_model's
-            # prefix_device_with_name flag.
-            #
-            # The historical default was false, but you really should switch it to true.
-            # First migrate little by little each call and then turn it on globally
-            # by setting this flag.
-            attr_accessor :prefix_device_with_name
-        end
-
-        @scope_device_name_with_links_and_submodels = false
-        @use_gazebo_automatic_links = true
-        @prefix_device_with_name = false
-
         # Gazebo-specific extensions to {Syskit::Robot::RobotDefinition}
         module RobotDefinitionExtension
             # Given a sensor, returns the device and device driver model that


### PR DESCRIPTION
The flags are declared in a features.rb file to make them easier to find / inspect. The PR also adds one for the default value of `prefix_device_with_name`.