### PR TITLE
fix: make sure use_gazebo_model does not need use_gazebo_world to function (on top of #65)

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit/features.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/features.rb
@@ -38,10 +38,18 @@ module RockGazebo
             # First migrate little by little each call and then turn it on globally
             # by setting this flag.
             attr_accessor :prefix_device_with_name
+
+            # Feature flag that controls whether use_gazebo_model calls use_gazebo_world
+            #
+            # The historical default was true, but will become false. If switching the
+            # flag to false globally does not work, a more gradual migration can be
+            # done by passing `use_world: false` to the use_gazebo_model call
+            attr_accessor :use_gazebo_model_calls_use_gazebo_world
         end
 
         @scope_device_name_with_links_and_submodels = false
         @use_gazebo_automatic_links = true
         @prefix_device_with_name = false
+        @use_gazebo_model_calls_use_gazebo_world = true
     end
 end

--- a/bindings/ruby/lib/rock_gazebo/syskit/profile_extension.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit/profile_extension.rb
@@ -143,8 +143,9 @@ module RockGazebo
             #   called at the end. You usually want this
             def use_gazebo_model(
                 *path,
-                filter: nil, as: nil, use_world: true,
-                reuse: nil, prefix_device_with_name: Syskit.prefix_device_with_name
+                filter: nil, as: nil, reuse: nil,
+                use_world: Syskit.use_gazebo_model_calls_use_gazebo_world,
+                prefix_device_with_name: Syskit.prefix_device_with_name
             )
                 use_sdf_model(*path, as: as, filter: filter)
                 model_in_world = resolve_model_in_world
@@ -170,10 +171,12 @@ module RockGazebo
 
                 reuse = reuse.robot if reuse.respond_to?(:robot)
                 sdf_world.each_model do |model|
-                    if model != enclosing_model
-                        robot.expose_gazebo_model(model, "gazebo::#{sdf_world.name}::",
-                            reuse: reuse)
-                    end
+                    next if model == enclosing_model
+
+                    robot.expose_gazebo_model(
+                        model, "gazebo::#{sdf_world.name}::",
+                        reuse: reuse
+                    )
                 end
             end
         end

--- a/bindings/ruby/test/worlds/attached_simple_model.world
+++ b/bindings/ruby/test/worlds/attached_simple_model.world
@@ -3,6 +3,7 @@
         <model name="attachment">
             <link name="in_attachment" />
             <include>
+                <pose>1 0 0 0 0 0</pose>
                 <name>included_model</name>
                 <uri>model://simple_model</uri>
             </include>


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/drivers-transformer/pull/18

It seems that `use_gazebo_world` has been added to `use_gazebo_model` one day as
a workaround for problems, probably related to hierarchical models.

This commit actually fixes that problem, making sure we do *not* need to call
use_gazebo_world - which has a very high cost in complex scenes, and pollutes
the transformer with a lot of unneeded frames.

The main issue was that the root model frame was not automatically added to the
transformer, but it is needed to actually run the ModelTask.