### PR TITLE
fix: do not assume the transformer cannot be already enabled

### DIFF
--- a/bindings/ruby/lib/rock_gazebo/syskit.rb
+++ b/bindings/ruby/lib/rock_gazebo/syskit.rb
@@ -11,7 +11,8 @@ require 'models/devices/gazebo/root_model'
 require 'models/devices/gazebo/link'
 require 'models/devices/gazebo/joint'
 require 'transformer/syskit'
-Transformer::SyskitPlugin.enable
+Syskit.conf.transformer_enabled = true
+
 require 'transformer/sdf'
 require 'rock_gazebo/syskit/features'
 require 'rock_gazebo/syskit/sdf'


### PR DESCRIPTION
The transformer is now complaining when Syskit.enable is called twice (this is actually a bug). Unfortunately, rock_gazebo/syskit enables the transformer "manually" - which it should really not do - and things fail if code enabled thet transformer explicitly before require'ing rock_gazebo/syskit.

Make sure that this is allowed and a no-op